### PR TITLE
feat: Add new Maven modules and update dependencies

### DIFF
--- a/dsd-controller/src/test/java/com/freelance/spring/controller/ControllerTest.java
+++ b/dsd-controller/src/test/java/com/freelance/spring/controller/ControllerTest.java
@@ -3,14 +3,12 @@ package com.freelance.spring.controller;
 import com.freelance.spring.config.Config;
 import com.freelance.spring.domain.Car;
 import com.freelance.spring.repository.CarRepository;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Arrays;
@@ -23,7 +21,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
 @WebMvcTest(controllers = Controller.class)
 @Import(Config.class)
 public class ControllerTest {

--- a/dsd-repository/src/main/java/com/freelance/spring/services/impl/CarServiceImpl.java
+++ b/dsd-repository/src/main/java/com/freelance/spring/services/impl/CarServiceImpl.java
@@ -40,12 +40,8 @@ public class CarServiceImpl implements CarService {
      */
     @Override
     public Car findById(String byManufacturer) throws CarServiceException {
-        Optional<Car> car = carRepository.findById(byManufacturer);
-
-        if (car == null) {
-            throw new CarServiceException("Manufacturer " + byManufacturer + " does not exist");
-        }
-        return car.get();
+        return carRepository.findById(byManufacturer)
+                .orElseThrow(() -> new CarServiceException("Manufacturer " + byManufacturer + " does not exist"));
     }
 
     /**

--- a/dsd-repository/src/test/java/com/freelance/spring/services/impl/TestCarServiceImpl.java
+++ b/dsd-repository/src/test/java/com/freelance/spring/services/impl/TestCarServiceImpl.java
@@ -4,11 +4,12 @@ import com.freelance.spring.domain.Car;
 import com.freelance.spring.exceptions.CarServiceException;
 import com.freelance.spring.repository.CarRepository;
 import com.freelance.spring.services.CarService;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.Mockito.*;
 
@@ -24,7 +25,7 @@ public class TestCarServiceImpl {
 
         List<Car> carList = carService.findAll();
 
-        Assert.assertTrue(!carList.isEmpty());
+        Assertions.assertTrue(!carList.isEmpty());
     }
 
     @Test
@@ -36,20 +37,19 @@ public class TestCarServiceImpl {
 
         Car car = carService.findById("Ferrari");
 
-        Assert.assertNotNull(car);
+        Assertions.assertNotNull(car);
     }
 
     @Test
     public void throwExceptionForNonExistingManufacturer() {
         CarRepository mockCarRepo = mock(CarRepository.class);
-        when(mockCarRepo.findById(anyString())).thenReturn(null);
+        when(mockCarRepo.findById(anyString())).thenReturn(Optional.empty());
         CarService carService = new CarServiceImpl(mockCarRepo);
 
-        try {
+        CarServiceException exception = Assertions.assertThrows(CarServiceException.class, () -> {
             carService.findById("Ferrari");
-            Assert.fail("Exception should had been thrown");
-        } catch (Exception e) {
-            Assert.assertEquals("Manufacturer Ferrari does not exist", e.getMessage());
-        }
+        });
+
+        Assertions.assertEquals("Manufacturer Ferrari does not exist", exception.getMessage());
     }
 }

--- a/incidentes/pom.xml
+++ b/incidentes/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.freelance.spring</groupId>
+        <artifactId>dsd</artifactId>
+        <version>1.0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>incidentes</artifactId>
+    <packaging>jar</packaging>
+
+</project>

--- a/llamadas/pom.xml
+++ b/llamadas/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.freelance.spring</groupId>
+        <artifactId>dsd</artifactId>
+        <version>1.0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>llamadas</artifactId>
+    <packaging>jar</packaging>
+
+</project>

--- a/localizaciones/pom.xml
+++ b/localizaciones/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.freelance.spring</groupId>
+        <artifactId>dsd</artifactId>
+        <version>1.0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>localizaciones</artifactId>
+    <packaging>jar</packaging>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -13,24 +13,29 @@
         <module>dsd-business</module>
         <module>dsd-repository</module>
         <module>dsd-controller</module>
+        <module>llamadas</module>
+        <module>localizaciones</module>
+        <module>incidentes</module>
     </modules>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.7.RELEASE</version>
+        <version>3.5.6</version>
     </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
+        <lombok.version>1.18.30</lombok.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -49,6 +54,21 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
+                <configuration>
+                    <fork>true</fork>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>


### PR DESCRIPTION
This commit adds three new Maven modules: `llamadas`, `localizaciones`, and `incidentes`.

It also updates the project to use modern dependencies to resolve build failures encountered with the previous setup.

Changes include:
- Upgraded Spring Boot to version 3.5.6
- Updated Java version to 17
- Upgraded Lombok to version 1.18.30
- Migrated tests from JUnit 4 to JUnit 5
- Configured the `maven-compiler-plugin` for compatibility with the new stack.